### PR TITLE
Bump keops to v2.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,8 +173,8 @@ install_requires = [
     'scikit-learn',
     'psutil',
     'dataclasses;python_version<"3.7"',
-    'keopscore @ git+https://github.com/getkeops/keops@ad044a671fdc3c2790b0321f6b9f9b5aa3d220df#subdirectory=keopscore',
-    'pykeops @ git+https://github.com/getkeops/keops@ad044a671fdc3c2790b0321f6b9f9b5aa3d220df#subdirectory=pykeops',
+    'keopscore @ git+https://github.com/getkeops/keops@v2.1.1#subdirectory=keopscore',
+    'pykeops @ git+https://github.com/getkeops/keops@v2.1.1#subdirectory=pykeops',
 ]
 test_requires = [
     'pandas',


### PR DESCRIPTION
keops was pinned to https://github.com/getkeops/keops/commit/ad044a671fdc3c2790b0321f6b9f9b5aa3d220df, but that commit seems to be contained in the [`v2.1.1`](https://github.com/getkeops/keops/releases/tag/v2.1.1) release that came out ~3 weeks ago (at the start of 2023), so let's try if it is possible to just use that release.